### PR TITLE
changed tolerance on WS2812B based on new source.

### DIFF
--- a/source/AsyncRgbLedAnalyzerSettings.cpp
+++ b/source/AsyncRgbLedAnalyzerSettings.cpp
@@ -77,13 +77,14 @@ void AsyncRgbLedAnalyzerSettings::InitControllerData()
             LAYOUT_RGB
         },
         // https://cdn-shop.adafruit.com/datasheets/WS2812B.pdf
+		// http://www.seeedstudio.com/document/pdf/WS2812B%20Datasheet.pdf
         {
             "WS2812B", "Worldsemi 24-bit RGB integrated light-source", 8, 3,
             {50_us, 50_us, 50_us},
             {
                 // low-speed times
-                {{250_ns, 400_ns, 550_ns}, {700_ns, 850_ns, 1000_ns}},     // 0-bit times
-                {{650_ns, 800_ns, 950_ns}, {300_ns, 450_ns, 600_ns}},  // 1-bit times
+                {{200_ns, 400_ns, 550_ns}, {700_ns, 850_ns, 1050_ns}},     // 0-bit times
+                {{650_ns, 800_ns, 1050_ns}, {200_ns, 450_ns, 600_ns}},  // 1-bit times
             },
             false, {{}, {}}, LAYOUT_GRB
         },


### PR DESCRIPTION
This PR is just for reference, you don't necessarily need to merge it.

I recommend we start a spreadsheet to hold tolerance data and spend a little more time searching the internet to see if there are alternate tolerances for some of the other parts - mainly the WS parts in particular, since they are so popular.

This change was also made in the Logic codebase.